### PR TITLE
Fix flag cutoff in LanguageSwitcher component

### DIFF
--- a/frontend/modules/shared/ui/src/lib/layout/language-switcher/language-switcher.component.html
+++ b/frontend/modules/shared/ui/src/lib/layout/language-switcher/language-switcher.component.html
@@ -14,7 +14,7 @@
     >
       <img
         [alt]="flag.key"
-        class="t-flag"
+        class="t-flag flag-border"
         height="20"
         width="27"
         [src]="flag.value | tuiFlag"
@@ -24,7 +24,7 @@
   <ng-template #flagContent let-locale>
     <img
       [alt]="locale"
-      class="t-flag"
+      class="t-flag flag-border"
       height="20"
       width="27"
       [src]="flags.get(locale) ?? '' | tuiFlag"

--- a/frontend/modules/shared/ui/src/lib/layout/language-switcher/language-switcher.component.scss
+++ b/frontend/modules/shared/ui/src/lib/layout/language-switcher/language-switcher.component.scss
@@ -1,3 +1,3 @@
 :host {
-  min-width: 80px;
+  min-width: 85px;
 }

--- a/frontend/modules/shared/ui/src/lib/layout/language-switcher/language-switcher.component.scss
+++ b/frontend/modules/shared/ui/src/lib/layout/language-switcher/language-switcher.component.scss
@@ -1,3 +1,8 @@
 :host {
   min-width: 85px;
 }
+
+.flag-border {
+  border: 1px solid var(--tui-base-04);
+  border-radius: var(--tui-radius-xs);
+}


### PR DESCRIPTION
Solves #197 

Sprawdziłem obie opcje i o ile rozmiar selecta "s" wygląda ok przy wyborze języka to w wyszukiwarce wygląda już słabo, a zależy mi żeby tą samą wysokość miały oba te inputy

Więc teraz language switcher jest 5px szerszy :D 

TopBar po zmianie:
![obraz](https://github.com/AdrianKokot/put-reunice-platform/assets/69046668/1bb8cb35-ffe5-47ac-8314-d3392b0b626a)
